### PR TITLE
Adds a button to toggle the visibility of scores

### DIFF
--- a/_layouts/profile-list.html
+++ b/_layouts/profile-list.html
@@ -8,11 +8,12 @@ layout: default
     {% include menu-profile.html %}
 </menu>
 
-<main>
+<main class="profile-list">
     <header>
         <h1>Achievements</h1>
     </header>
 
     {{ content }}
-
 </main>
+
+<script src="{{ site.baseurl }}/js/toggle-all-scores.js"></script>

--- a/css/modules/profile-summary.css
+++ b/css/modules/profile-summary.css
@@ -121,15 +121,18 @@
     }
 
 /*-------( Hover States )-------------------------------------------------------*/
+    .show-all-scores .profile-summary,
     .profile-summary:hover {
         border-color: rgba(0, 0, 0, 0.2);
         transform: rotateY( -180deg );
     }
 
+    .show-all-scores .profile-summary .profile-summary__icon,
     .profile-summary:hover .profile-summary__icon {
         /*border-color: rgba(0, 0, 0, 0.2);*/
     }
 
+    .show-all-scores .profile-summary .profile-summary__name,
     .profile-summary:hover .profile-summary__name {
         transform: rotateY( -180deg);
     }

--- a/js/toggle-all-scores.js
+++ b/js/toggle-all-scores.js
@@ -1,0 +1,48 @@
+/**
+ * When clicked, the button added by this module toggles the visibility of the 
+ * scores of all of the profiles in the list by toggling a class on the container. 
+ */
+;(function (root, p_sContainerSelector, p_sToggleClass) {
+    'use strict';
+
+    var oContainer, oButton;
+
+    function toggleScores (){
+        var bView, sBackgroundColor, sColor, sText;
+
+        bView = oContainer.classList.toggle(p_sToggleClass);
+
+        if (bView) {
+            sBackgroundColor = 'rgb(255,255,255)';
+            sColor = 'rgb( 250, 182, 9)';
+            sText = 'Score always visible';
+        } else {
+            sBackgroundColor = 'rgb( 250, 182, 9)';
+            sColor = 'rgb(255,255,255)';
+            sText = 'Score visible on hover';
+        }
+        oButton.textContent = sText;
+        oButton.style.backgroundColor = sBackgroundColor;
+        oButton.style.color = sColor;
+    }
+    
+    oContainer = document.querySelector(p_sContainerSelector);
+    oButton = document.createElement('div');
+    oButton.textContent = 'Score visible on hover';
+    oButton.setAttribute('style', '\
+        position: fixed;\
+        top: 0;\
+        right: 0;\
+        margin: 0.5em;\
+        padding: 0.25em 0.5em;\
+        border-radius: 1em;\
+        color: rgb(255,255,255);\
+        border: 0.1em solid rgb( 250, 182, 9);\
+        background-color: rgb( 250, 182, 9);\
+        cursor: pointer;\
+    ');
+    oContainer.appendChild(oButton);
+
+    oButton.addEventListener('click', toggleScores);
+}(window, '.profile-list', 'show-all-scores'))
+/*EOF*/


### PR DESCRIPTION
I've added a "button" to the top-right corner that displays the current "score view mode". 
The default is the current behaviour, displaying scores when they are hovered.
When the "button" is clicked, it changes the scores visibility to "always visible".

Working version at: https://potherca-contrib.github.io/Achievements/