### PR TITLE
Paasei voor Ferry

### DIFF
--- a/_profiles/ferry-joosten.md
+++ b/_profiles/ferry-joosten.md
@@ -8,7 +8,7 @@ achievements :
   crayons       : 0
   darts         : 0
   dealerdirect  : 0
-  easteregg     : 1
+  easteregg     : 2
   fry           : 0
   happy         : 0
   idea          : 0


### PR DESCRIPTION
Omdat hij kwam vragen om een IP te whitelisten zonder het IP adres te weten dat gewhitelist moest worden.