### PR TITLE
Fixes unwanted badge highlight

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -18,9 +18,9 @@ layout: profile-list
         <ul>
         {% for badgeName in badges %}
             {% assign score = page.achievements[badgeName] %}
-            <li {% if score != 0 %}class="scored"{% endif %}>
+            <li {% if score > 0  %}class="scored"{% endif %}>
                 <img src="{{ site.baseurl }}/img/badges/svg/badge_{{ badgeName }}.svg" />
-                {% if score != 0 %}
+                {% if score > 0 %}
                 <span class="score">{{ score }}</span>
                 {% endif %}
             </li>


### PR DESCRIPTION
Badges that were not present in a persons profile were not grayed-out because of an incorrect comparison.

This PR fixes that.